### PR TITLE
Add basic retry error handling

### DIFF
--- a/bark_infinity/error_handling.py
+++ b/bark_infinity/error_handling.py
@@ -1,0 +1,45 @@
+import functools
+import sys
+import time
+from .config import logger
+
+
+def retry_on_exception(max_retries=3, delay=1.0):
+    """Decorator to retry a function if it raises an exception."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempt in range(1, max_retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.error(
+                        "Attempt %s/%s failed in %s: %s",
+                        attempt,
+                        max_retries,
+                        func.__name__,
+                        e,
+                    )
+                    time.sleep(delay)
+            logger.error("%s failed after %s attempts", func.__name__, max_retries)
+            return None
+
+        return wrapper
+
+    return decorator
+
+
+def set_global_exception_logger():
+    """Log uncaught exceptions using the project logger."""
+
+    def handle_exception(exc_type, exc_value, exc_traceback):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+        logger.error(
+            "Uncaught exception",
+            exc_info=(exc_type, exc_value, exc_traceback),
+        )
+
+    sys.excepthook = handle_exception

--- a/bark_perform.py
+++ b/bark_perform.py
@@ -9,6 +9,7 @@ logger = config.logger
 
 from bark_infinity import generation
 from bark_infinity import api
+from bark_infinity import error_handling
 
 from bark_infinity import text_processing
 
@@ -39,6 +40,7 @@ def get_group_args(group_name, updated_args):
     return group_args
 
 def main(args):
+    error_handling.set_global_exception_logger()
 
     if args.loglevel is not None:
         logger.setLevel(args.loglevel)
@@ -113,7 +115,8 @@ def main(args):
             args.text_prompt = text_prompt
             args_dict = vars(args)
 
-            api.generate_audio_long(**args_dict)
+            safe_generate = error_handling.retry_on_exception()(api.generate_audio_long)
+            safe_generate(**args_dict)
 
 
 if __name__ == "__main__":

--- a/bark_streamlit.py
+++ b/bark_streamlit.py
@@ -6,9 +6,10 @@ import subprocess
 
 import streamlit as st
 
-from bark_infinity import api, config
+from bark_infinity import api, config, error_handling
 
 logger = config.logger
+error_handling.set_global_exception_logger()
 
 REQUIREMENTS = "requirements-pip.txt"
 
@@ -92,7 +93,8 @@ def main():
             "waveform_temp": waveform_temp,
         }
         st.write("Generating audio ...")
-        filename = api.generate_audio_long_from_gradio(**kwargs)
+        safe_generate = error_handling.retry_on_exception()(api.generate_audio_long_from_gradio)
+        filename = safe_generate(**kwargs)
         if filename and os.path.exists(filename):
             st.audio(filename)
             st.success(f"Saved to {filename}")

--- a/bark_webui.py
+++ b/bark_webui.py
@@ -13,9 +13,11 @@ from bark_infinity import config
 
 logger = config.logger
 logger.setLevel("INFO")
+error_handling.set_global_exception_logger()
 
 from bark_infinity import generation
 from bark_infinity import api
+from bark_infinity import error_handling
 
 
 generation.OFFLOAD_CPU = True
@@ -211,7 +213,8 @@ def generate_audio_long_gradio(input, npz_dropdown, generated_voices, confused_t
     print(f"Using these params: {using_these_params}")
 
 
-    full_generation_segments, audio_arr_segments, final_filename_will_be = api.generate_audio_long_from_gradio(**kwargs)
+    safe_generate = error_handling.retry_on_exception()(api.generate_audio_long_from_gradio)
+    full_generation_segments, audio_arr_segments, final_filename_will_be = safe_generate(**kwargs)
 
     if kwargs.get('dry_run', False):
         final_filename_will_be = "bark_infinity/assets/split_the_text.wav"


### PR DESCRIPTION
## Summary
- add a new `error_handling` module that retries failed operations and logs uncaught exceptions
- integrate global exception logging and retry wrappers into `bark_perform.py`, `bark_streamlit.py`, and `bark_webui.py`

## Testing
- `python -m py_compile bark_infinity/error_handling.py bark_perform.py bark_streamlit.py bark_webui.py`

------
https://chatgpt.com/codex/tasks/task_e_6844c8700b188327af2443e9e7c92550