### PR TITLE
Add FusionTransformer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,3 +447,17 @@ os.environ["SUNO_USE_SMALL_MODELS"] = True
 
 #### My generated audio sounds like a 1980s phone call. What's happening?
 * Bark generates audio from scratch. It is not meant to create only high-fidelity, studio-quality speech. Rather, outputs could be anything from perfect speech to multiple people arguing at a baseball game recorded with bad microphones.
+
+## Fusion Transformer
+
+`FusionTransformer` enables experimentation with a mixture-of-experts approach.
+It loads a list of Hugging Face models and learns weights that combine their
+hidden states.
+
+```python
+from bark_infinity import FusionTransformer
+
+model = FusionTransformer(["bert-base-uncased", "roberta-base"])
+inputs = model.encode("hello world")
+output = model(**inputs)
+```

--- a/bark_infinity/__init__.py
+++ b/bark_infinity/__init__.py
@@ -5,3 +5,4 @@ from .generation import SAMPLE_RATE, preload_models
 from .api import generate_audio_long, render_npz_samples, list_speakers
 from .config import logger, console, get_default_values, load_all_defaults, VALID_HISTORY_PROMPT_DIRS
 
+from .fusion_transformer import FusionTransformer

--- a/bark_infinity/fusion_transformer.py
+++ b/bark_infinity/fusion_transformer.py
@@ -1,0 +1,34 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import AutoModel, AutoTokenizer
+
+class FusionTransformer(nn.Module):
+    """Simple mixture-of-experts transformer fusion.
+
+    Each expert is an arbitrary Hugging Face transformer model. The module learns
+    a weight for each expert and combines their hidden states.
+    """
+
+    def __init__(self, model_names):
+        super().__init__()
+        if not model_names:
+            raise ValueError("model_names must contain at least one model identifier")
+        self.tokenizers = [AutoTokenizer.from_pretrained(name) for name in model_names]
+        self.models = nn.ModuleList([AutoModel.from_pretrained(name) for name in model_names])
+        self.logits_weight = nn.Parameter(torch.ones(len(self.models)))
+
+    def encode(self, text):
+        """Tokenize input text using the first tokenizer."""
+        tokenizer = self.tokenizers[0]
+        return tokenizer(text, return_tensors="pt")
+
+    def forward(self, input_ids, attention_mask=None):
+        hidden_states = []
+        for model in self.models:
+            outputs = model(input_ids=input_ids, attention_mask=attention_mask)
+            hidden_states.append(outputs.last_hidden_state)
+        stacked = torch.stack(hidden_states, dim=0)
+        weights = F.softmax(self.logits_weight, dim=0)
+        fused = torch.sum(weights.view(-1, 1, 1, 1) * stacked, dim=0)
+        return fused


### PR DESCRIPTION
## Summary
- add `FusionTransformer` module implementing a simple mixture-of-experts approach
- re-export `FusionTransformer` in package `__init__`
- document new fusion model in README

## Testing
- `python -m py_compile bark_infinity/fusion_transformer.py`
- `python -m py_compile bark_infinity/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6844cab88ce48327b9546c1793ac5c17